### PR TITLE
Fix invalid mu and raise warning instead of error

### DIFF
--- a/modcma/parameters.py
+++ b/modcma/parameters.py
@@ -416,10 +416,11 @@ class Parameters(AnnotatedStruct):
                 
         self.mu = self.mu or self.lambda_ // 2
         if self.mu > self.lambda_:
-            raise AttributeError(
+            self.mu = self.lambda_
+            warnings.warn(
                 "\u03BC ({}) cannot be larger than \u03bb ({})".format(
                     self.mu, self.lambda_
-                ))
+                ), RuntimeWarning)
         
         self.seq_cutoff = self.mu * self.seq_cutoff_factor
         self.sampler = self.get_sampler() 

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -55,9 +55,8 @@ class TestParameters(unittest.TestCase):
             self.assertEqual(sampler.__name__, 'mirrored_sampling')
 
     def test_wrong_parameters(self):
-        with self.assertRaises(AttributeError):
+        with self.assertWarns(RuntimeWarning):
             Parameters(1, mu=3, lambda_=2)
-
 
     def test_options(self):
         for module in Parameters.__modules__:


### PR DESCRIPTION
This fixes too large values of mu instead of throwing an error.
This is useful for the dynamic algorithm configuration case, since changing from a high to low population can then be done without tuning the corresponding mu.