### PR TITLE
Minor bugfix of #7

### DIFF
--- a/modcma/parameters.py
+++ b/modcma/parameters.py
@@ -416,11 +416,11 @@ class Parameters(AnnotatedStruct):
                 
         self.mu = self.mu or self.lambda_ // 2
         if self.mu > self.lambda_:
-            self.mu = self.lambda_
             warnings.warn(
-                "\u03BC ({}) cannot be larger than \u03bb ({})".format(
-                    self.mu, self.lambda_
-                ), RuntimeWarning)
+                "\u03BC ({}) cannot be larger than \u03bb ({}). Modifying \u03bb to ".format(
+                    self.mu, self.lambda_, self.lambda_ // 2
+                ), RuntimeWarning)            
+            self.mu = self.lambda_ // 2
         
         self.seq_cutoff = self.mu * self.seq_cutoff_factor
         self.sampler = self.get_sampler() 

--- a/modcma/parameters.py
+++ b/modcma/parameters.py
@@ -417,7 +417,7 @@ class Parameters(AnnotatedStruct):
         self.mu = self.mu or self.lambda_ // 2
         if self.mu > self.lambda_:
             warnings.warn(
-                "\u03BC ({}) cannot be larger than \u03bb ({}). Modifying \u03bb to ".format(
+                "\u03BC ({}) cannot be larger than \u03bb ({}). Modifying \u03bb to ({})".format(
                     self.mu, self.lambda_, self.lambda_ // 2
                 ), RuntimeWarning)            
             self.mu = self.lambda_ // 2


### PR DESCRIPTION
I realized the ordering of the warning was wrong so it is less informative. 
This also changes the fixing of mu to lambda//2 instead of lambda, which corresponds to the default initialization