### PR TITLE
Make sure lambda_ is even when using bipop

### DIFF
--- a/modcma/parameters.py
+++ b/modcma/parameters.py
@@ -76,6 +76,8 @@ class BIPOPParameters(AnnotatedStruct):
                 .5 * self.lambda_large / self.lambda_init
                 ) ** (np.random.random() ** 2)
             ).astype(int)
+        if self.lambda_small % 2 != 0:
+            self.lambda_small += 1
 
 
 class Parameters(AnnotatedStruct):


### PR DESCRIPTION
An issue occurs when bipop is used in combination with mirrored pairwise sampling when the lambda_small becomes odd.
This is a quick fix for this issue, but it would probably be better to only update this conditionally if needed (the bipop-parameters currently don't know if this sampling is used).