### PR TITLE
Modification to initial sigma value

### DIFF
--- a/modcma/parameters.py
+++ b/modcma/parameters.py
@@ -244,7 +244,7 @@ class Parameters(AnnotatedStruct):
     n_generations: int = None
     lambda_: int = None
     mu: int = None
-    sigma0: float = 0.5
+    sigma0: float = 0.2
     a_tpa: float = 0.5
     b_tpa: float = 0.0
     cs: float = None
@@ -463,9 +463,9 @@ class Parameters(AnnotatedStruct):
         Examples of such parameters are the Covariance matrix C and its 
         eigenvectors and the learning rate sigma.
         """
-        self.sigma = np.float64(self.sigma0)
+        self.sigma = np.float64(self.sigma0) * (self.ub[0,0] - self.lb[0,0])
         if hasattr(self, "m") or self.x0 is None: 
-            self.m = np.float64(np.random.uniform(self.lb, self.ub, (self.d, 1))
+            self.m = np.float64(np.random.uniform(self.lb, self.ub, (self.d, 1)))
         else:
             self.m = np.float64(self.x0.copy())
         self.m_old = np.empty((self.d, 1), dtype=np.float64)


### PR DESCRIPTION
The default value of sigma is currently independent from the domain size, which can lead to issues when comparing runs across problems with different domains. 
The fix in this PR is very basic, and assumes equal size box-constraints for all dimensions. If this is not the case, we probably should set the initial sigma to be based on the maximum dimension length, and update the initial covariance matrix accordingly. 
This also doesn't handle the sigma-values used in BIPOP, which we should probably discuss before merging this PR